### PR TITLE
Move `ember-cli-htmlbars` to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,8 +30,7 @@
     "test:ember-compatibility": "ember try:each"
   },
   "dependencies": {
-    "ember-cli-babel": "^7.18.0",
-    "ember-cli-htmlbars": "^5.1.1"
+    "ember-cli-babel": "^7.18.0"
   },
   "devDependencies": {
     "@ember/optional-features": "^1.3.0",
@@ -45,6 +44,7 @@
     "ember-chat": "link:./tests/dummy/lib/ember-chat",
     "ember-cli": "~3.17.0",
     "ember-cli-dependency-checker": "^3.2.0",
+    "ember-cli-htmlbars": "^5.1.1",
     "ember-cli-inject-live-reload": "^2.0.2",
     "ember-cli-sri": "^2.1.1",
     "ember-cli-uglify": "^3.0.0",


### PR DESCRIPTION
As this addon does not ship any hbs files, there is no need to include `ember-cli-htmlbars` in it's dependencies.