### PR TITLE
copy `*.md` files to addon via release-it hook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,11 @@
-node_modules
+# dependencies
+node_modules/
+
+# *.md copies from release
+/addon/README.md
+/addon/LICENSE.md
+
+# misc
+npm-debug.log*
 yarn-error.log
 .DS_Store

--- a/package.json
+++ b/package.json
@@ -22,6 +22,9 @@
     "registry": "https://registry.npmjs.org"
   },
   "release-it": {
+    "hooks": {
+      "before:init": "cp README.md LICENSE.md addon/"
+    },
     "plugins": {
       "release-it-lerna-changelog": {
         "infile": "CHANGELOG.md",


### PR DESCRIPTION
doing so, we ensure README.md and LICENSE.md are present in the addon folder
during release so they will get into tarball and get published to the npmjs.com