### PR TITLE
Drop Node.js 12 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,9 +19,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Install Node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
-          node-version: 12.x
+          node-version: 14.x
           cache: yarn
       - name: Install Dependencies
         run: until yarn install --frozen-lockfile; do echo "Retrying yarn"; done
@@ -41,9 +41,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
-          node-version: 12.x
+          node-version: 14.x
           cache: yarn
       - name: Install Dependencies
         # Absurdly, yarn always fails on the first try here.
@@ -78,9 +78,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Install Node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
-          node-version: 12.x
+          node-version: 14.x
           cache: yarn
       - name: Install Dependencies
         run: until yarn install --frozen-lockfile; do echo "Retrying yarn"; done

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This addon provides an API for authoring a [Router service](https://api.emberjs.
 
 * Ember.js v3.12 or above
 * Ember CLI v3.24 or above
-* Node.js v12 or above
+* Node.js v14 or above
 
 
 ## Installation

--- a/addon/package.json
+++ b/addon/package.json
@@ -45,7 +45,7 @@
     "rollup": "^2.70.1"
   },
   "engines": {
-    "node": "12.* || 14.* || >= 16"
+    "node": "14.* || 16.* || >= 18"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org"

--- a/package.json
+++ b/package.json
@@ -53,5 +53,9 @@
       "tokenRef": "GITHUB_AUTH"
     },
     "npm": false
+  },
+  "volta": {
+    "node": "14.19.2",
+    "yarn": "1.22.18"
   }
 }

--- a/test-app/package.json
+++ b/test-app/package.json
@@ -77,7 +77,7 @@
     "webpack": "^5.68.0"
   },
   "engines": {
-    "node": "12.* || 14.* || >= 16"
+    "node": "14.* || 16.* || >= 18"
   },
   "changelog": {
     "repo": "villander/ember-engines-router-service",


### PR DESCRIPTION
Node.js 12 was End Of Line last month on April 30, 2022

@villander it worth including in the next major v0.4.0