### PR TITLE
Remove engines/node from package.json

### DIFF
--- a/ember-engines-router-service/package.json
+++ b/ember-engines-router-service/package.json
@@ -59,9 +59,6 @@
   "peerDependencies": {
     "ember-source": "^3.28.0 || ^4.0.0"
   },
-  "engines": {
-    "node": "16.* || 18.* || >= 20"
-  },
   "publishConfig": {
     "registry": "https://registry.npmjs.org"
   },


### PR DESCRIPTION
v2 addons are pure npm/JS packages with no Node.js runtime.

Hence, v2 addons do not depend on any specific version of Node.js

Without having this dormant yet explicitly listed on package.json, we can update Node.js version in CI and elsewhere without need to publish major version.