### PR TITLE
Allow Ember.js v5 in peerDependencies

### DIFF
--- a/ember-engines-router-service/package.json
+++ b/ember-engines-router-service/package.json
@@ -57,7 +57,7 @@
     "rollup": "^3.8.1"
   },
   "peerDependencies": {
-    "ember-source": "^3.28.0 || ^4.0.0"
+    "ember-source": "^3.28.0 || ^4.0.0 || ^5.0.0"
   },
   "engines": {
     "node": "16.* || 18.* || >= 20"


### PR DESCRIPTION
Ember.js v5 reached 5.4 so this is required for anyone updating to ember-source@^5.0.0