### PR TITLE
Update exports field in package.json to make TypeScript imports work

### DIFF
--- a/ember-engines-router-service/package.json
+++ b/ember-engines-router-service/package.json
@@ -13,7 +13,10 @@
   "author": "",
   "exports": {
     ".": "./dist/addon-main.js",
-    "./*": "./dist/*",
+    "./*": {
+      "types": "./types/*.d.ts",
+      "default": "./dist/*.js"
+    },
     "./addon-main.js": "./addon-main.js"
   },
   "typesVersions": {


### PR DESCRIPTION
As types are found in separate folder from code, we should tell TypeScript where to look them up